### PR TITLE
feat: add new `label` and `assume` cheatcodes

### DIFF
--- a/contracts/interfaces.sol
+++ b/contracts/interfaces.sol
@@ -83,6 +83,12 @@ interface Vm {
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
 
+    // Gets the code from an artifact file. Takes in the relative path to the json file
     function getCode(string calldata) external returns (bytes memory);
 
+    // Labels an address in call traces
+    function label(address, string calldata) external;
+    
+    // If the condition is false, discard this run's fuzz inputs and generate new ones
+    function assume(bool) external;
 }


### PR DESCRIPTION
adds the following:

```ts
    // Labels an address in call traces
    function label(address, string calldata) external;
    
    // If the condition is false, discard this run's fuzz inputs and generate new ones
    function assume(bool) external;
```