### PR TITLE
feat: Add logging to `TestUtils`

### DIFF
--- a/contracts/DSTest.sol
+++ b/contracts/DSTest.sol
@@ -16,8 +16,6 @@
 pragma solidity >=0.4.23;
 
 contract DSTest {
-    event log                    (string);
-    event logs                   (bytes);
 
     event log_address            (address);
     event log_bytes32            (bytes32);
@@ -57,7 +55,7 @@ contract DSTest {
 
     function assertTrue(bool condition) internal {
         if (!condition) {
-            emit log("Error: Assertion Failed");
+            emit log_string("Error: Assertion Failed");
             fail();
         }
     }
@@ -71,7 +69,7 @@ contract DSTest {
 
     function assertEq(address a, address b) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [address]");
+            emit log_string("Error: a == b not satisfied [address]");
             emit log_named_address("  Expected", b);
             emit log_named_address("    Actual", a);
             fail();
@@ -86,7 +84,7 @@ contract DSTest {
 
     function assertEq(bytes32 a, bytes32 b) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [bytes32]");
+            emit log_string("Error: a == b not satisfied [bytes32]");
             emit log_named_bytes32("  Expected", b);
             emit log_named_bytes32("    Actual", a);
             fail();
@@ -107,7 +105,7 @@ contract DSTest {
 
     function assertEq(int a, int b) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [int]");
+            emit log_string("Error: a == b not satisfied [int]");
             emit log_named_int("  Expected", b);
             emit log_named_int("    Actual", a);
             fail();
@@ -121,7 +119,7 @@ contract DSTest {
     }
     function assertEq(uint a, uint b) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [uint]");
+            emit log_string("Error: a == b not satisfied [uint]");
             emit log_named_uint("  Expected", b);
             emit log_named_uint("    Actual", a);
             fail();
@@ -135,7 +133,7 @@ contract DSTest {
     }
     function assertEqDecimal(int a, int b, uint decimals) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [decimal int]");
+            emit log_string("Error: a == b not satisfied [decimal int]");
             emit log_named_decimal_int("  Expected", b, decimals);
             emit log_named_decimal_int("    Actual", a, decimals);
             fail();
@@ -149,7 +147,7 @@ contract DSTest {
     }
     function assertEqDecimal(uint a, uint b, uint decimals) internal {
         if (a != b) {
-            emit log("Error: a == b not satisfied [decimal uint]");
+            emit log_string("Error: a == b not satisfied [decimal uint]");
             emit log_named_decimal_uint("  Expected", b, decimals);
             emit log_named_decimal_uint("    Actual", a, decimals);
             fail();
@@ -164,7 +162,7 @@ contract DSTest {
 
     function assertGt(uint a, uint b) internal {
         if (a <= b) {
-            emit log("Error: a > b not satisfied [uint]");
+            emit log_string("Error: a > b not satisfied [uint]");
             emit log_named_uint("  Value a", a);
             emit log_named_uint("  Value b", b);
             fail();
@@ -178,7 +176,7 @@ contract DSTest {
     }
     function assertGt(int a, int b) internal {
         if (a <= b) {
-            emit log("Error: a > b not satisfied [int]");
+            emit log_string("Error: a > b not satisfied [int]");
             emit log_named_int("  Value a", a);
             emit log_named_int("  Value b", b);
             fail();
@@ -192,7 +190,7 @@ contract DSTest {
     }
     function assertGtDecimal(int a, int b, uint decimals) internal {
         if (a <= b) {
-            emit log("Error: a > b not satisfied [decimal int]");
+            emit log_string("Error: a > b not satisfied [decimal int]");
             emit log_named_decimal_int("  Value a", a, decimals);
             emit log_named_decimal_int("  Value b", b, decimals);
             fail();
@@ -206,7 +204,7 @@ contract DSTest {
     }
     function assertGtDecimal(uint a, uint b, uint decimals) internal {
         if (a <= b) {
-            emit log("Error: a > b not satisfied [decimal uint]");
+            emit log_string("Error: a > b not satisfied [decimal uint]");
             emit log_named_decimal_uint("  Value a", a, decimals);
             emit log_named_decimal_uint("  Value b", b, decimals);
             fail();
@@ -221,7 +219,7 @@ contract DSTest {
 
     function assertGe(uint a, uint b) internal {
         if (a < b) {
-            emit log("Error: a >= b not satisfied [uint]");
+            emit log_string("Error: a >= b not satisfied [uint]");
             emit log_named_uint("  Value a", a);
             emit log_named_uint("  Value b", b);
             fail();
@@ -235,7 +233,7 @@ contract DSTest {
     }
     function assertGe(int a, int b) internal {
         if (a < b) {
-            emit log("Error: a >= b not satisfied [int]");
+            emit log_string("Error: a >= b not satisfied [int]");
             emit log_named_int("  Value a", a);
             emit log_named_int("  Value b", b);
             fail();
@@ -249,7 +247,7 @@ contract DSTest {
     }
     function assertGeDecimal(int a, int b, uint decimals) internal {
         if (a < b) {
-            emit log("Error: a >= b not satisfied [decimal int]");
+            emit log_string("Error: a >= b not satisfied [decimal int]");
             emit log_named_decimal_int("  Value a", a, decimals);
             emit log_named_decimal_int("  Value b", b, decimals);
             fail();
@@ -263,7 +261,7 @@ contract DSTest {
     }
     function assertGeDecimal(uint a, uint b, uint decimals) internal {
         if (a < b) {
-            emit log("Error: a >= b not satisfied [decimal uint]");
+            emit log_string("Error: a >= b not satisfied [decimal uint]");
             emit log_named_decimal_uint("  Value a", a, decimals);
             emit log_named_decimal_uint("  Value b", b, decimals);
             fail();
@@ -278,7 +276,7 @@ contract DSTest {
 
     function assertLt(uint a, uint b) internal {
         if (a >= b) {
-            emit log("Error: a < b not satisfied [uint]");
+            emit log_string("Error: a < b not satisfied [uint]");
             emit log_named_uint("  Value a", a);
             emit log_named_uint("  Value b", b);
             fail();
@@ -292,7 +290,7 @@ contract DSTest {
     }
     function assertLt(int a, int b) internal {
         if (a >= b) {
-            emit log("Error: a < b not satisfied [int]");
+            emit log_string("Error: a < b not satisfied [int]");
             emit log_named_int("  Value a", a);
             emit log_named_int("  Value b", b);
             fail();
@@ -306,7 +304,7 @@ contract DSTest {
     }
     function assertLtDecimal(int a, int b, uint decimals) internal {
         if (a >= b) {
-            emit log("Error: a < b not satisfied [decimal int]");
+            emit log_string("Error: a < b not satisfied [decimal int]");
             emit log_named_decimal_int("  Value a", a, decimals);
             emit log_named_decimal_int("  Value b", b, decimals);
             fail();
@@ -320,7 +318,7 @@ contract DSTest {
     }
     function assertLtDecimal(uint a, uint b, uint decimals) internal {
         if (a >= b) {
-            emit log("Error: a < b not satisfied [decimal uint]");
+            emit log_string("Error: a < b not satisfied [decimal uint]");
             emit log_named_decimal_uint("  Value a", a, decimals);
             emit log_named_decimal_uint("  Value b", b, decimals);
             fail();
@@ -335,7 +333,7 @@ contract DSTest {
 
     function assertLe(uint a, uint b) internal {
         if (a > b) {
-            emit log("Error: a <= b not satisfied [uint]");
+            emit log_string("Error: a <= b not satisfied [uint]");
             emit log_named_uint("  Value a", a);
             emit log_named_uint("  Value b", b);
             fail();
@@ -349,7 +347,7 @@ contract DSTest {
     }
     function assertLe(int a, int b) internal {
         if (a > b) {
-            emit log("Error: a <= b not satisfied [int]");
+            emit log_string("Error: a <= b not satisfied [int]");
             emit log_named_int("  Value a", a);
             emit log_named_int("  Value b", b);
             fail();
@@ -363,7 +361,7 @@ contract DSTest {
     }
     function assertLeDecimal(int a, int b, uint decimals) internal {
         if (a > b) {
-            emit log("Error: a <= b not satisfied [decimal int]");
+            emit log_string("Error: a <= b not satisfied [decimal int]");
             emit log_named_decimal_int("  Value a", a, decimals);
             emit log_named_decimal_int("  Value b", b, decimals);
             fail();
@@ -377,7 +375,7 @@ contract DSTest {
     }
     function assertLeDecimal(uint a, uint b, uint decimals) internal {
         if (a > b) {
-            emit log("Error: a <= b not satisfied [decimal uint]");
+            emit log_string("Error: a <= b not satisfied [decimal uint]");
             emit log_named_decimal_uint("  Value a", a, decimals);
             emit log_named_decimal_uint("  Value b", b, decimals);
             fail();
@@ -392,7 +390,7 @@ contract DSTest {
 
     function assertEq(string memory a, string memory b) internal {
         if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
-            emit log("Error: a == b not satisfied [string]");
+            emit log_string("Error: a == b not satisfied [string]");
             emit log_named_string("  Value a", a);
             emit log_named_string("  Value b", b);
             fail();
@@ -419,7 +417,7 @@ contract DSTest {
     }
     function assertEq0(bytes memory a, bytes memory b) internal {
         if (!checkEq0(a, b)) {
-            emit log("Error: a == b not satisfied [bytes]");
+            emit log_string("Error: a == b not satisfied [bytes]");
             emit log_named_bytes("  Expected", a);
             emit log_named_bytes("    Actual", b);
             fail();

--- a/contracts/log.sol
+++ b/contracts/log.sol
@@ -2,6 +2,7 @@
 pragma solidity >= 0.4.22 <0.9.0;
 
 library console {
+
 	address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
 
 	function _sendLogPayload(bytes memory payload) private view {

--- a/contracts/test.sol
+++ b/contracts/test.sol
@@ -170,16 +170,36 @@ contract TestUtils is DSTest {
 		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
 	}
 
-    function log(int256 p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    function log(int p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(int)", p0));
 	}
 
     function log(string memory p0) internal view {
 		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
 	}
 
-    function log(uint256 p0) internal view {
+    function log(uint p0) internal view {
 		_sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+	}
+
+    function log(string memory p0, address p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+	}
+
+	function log(string memory p0, bool p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+	}
+
+    function log(string memory p0, int p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,int)", p0, p1));
+	}
+
+    function log(string memory p0, string memory p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+	}
+
+    function log(string memory p0, uint p1) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
 	}
 
 }

--- a/contracts/test.sol
+++ b/contracts/test.sol
@@ -21,14 +21,14 @@ contract TestUtils is DSTest {
     Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     function _sendLogPayload(bytes memory payload) private view {
-		address consoleAddress = CONSOLE_ADDRESS;
-		uint256 payloadLength = payload.length;
+        address consoleAddress = CONSOLE_ADDRESS;
+        uint256 payloadLength = payload.length;
 
-		assembly {
-			let payloadStart := add(payload, 32)
-			let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
-		}
-	}
+        assembly {
+            let payloadStart := add(payload, 32)
+            let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+        }
+    }
 
     function getDiff(uint256 x, uint256 y) internal pure returns (uint256 diff) {
         diff = x > y ? x - y : y - x;
@@ -163,36 +163,36 @@ contract TestUtils is DSTest {
     }
 
     function log(address p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(address)", p0));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+    }
 
-	function log(bool p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
-	}
+    function log(bool p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+    }
 
     function log(string memory p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+    }
 
     function log(uint p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    }
 
     function log(string memory p0, address p1) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
+    }
 
-	function log(string memory p0, bool p1) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
-	}
+    function log(string memory p0, bool p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
+    }
 
     function log(string memory p0, string memory p1) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
+    }
 
     function log(string memory p0, uint p1) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
-	}
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
+    }
 
 }
 

--- a/contracts/test.sol
+++ b/contracts/test.sol
@@ -11,12 +11,24 @@ contract Address { }
 
 contract TestUtils is DSTest {
 
-    uint256 private constant RAY = 10 ** 27;
-
-    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
 
     bytes constant ARITHMETIC_ERROR = abi.encodeWithSignature("Panic(uint256)", 0x11);
     bytes constant ZERO_DIVISION    = abi.encodeWithSignature("Panic(uint256)", 0x12);
+
+    uint256 constant RAY = 10 ** 27;
+
+    Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+    function _sendLogPayload(bytes memory payload) private view {
+		address consoleAddress = CONSOLE_ADDRESS;
+		uint256 payloadLength = payload.length;
+
+		assembly {
+			let payloadStart := add(payload, 32)
+			let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
+		}
+	}
 
     function getDiff(uint256 x, uint256 y) internal pure returns (uint256 diff) {
         diff = x > y ? x - y : y - x;
@@ -149,6 +161,26 @@ contract TestUtils is DSTest {
 
         return string(output);
     }
+
+    function log(address p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(address)", p0));
+	}
+
+	function log(bool p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
+	}
+
+    function log(int256 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+	}
+
+    function log(string memory p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
+	}
+
+    function log(uint256 p0) internal view {
+		_sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+	}
 
 }
 

--- a/contracts/test.sol
+++ b/contracts/test.sol
@@ -170,10 +170,6 @@ contract TestUtils is DSTest {
 		_sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
 	}
 
-    function log(int p0) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(int)", p0));
-	}
-
     function log(string memory p0) internal view {
 		_sendLogPayload(abi.encodeWithSignature("log(string)", p0));
 	}
@@ -188,10 +184,6 @@ contract TestUtils is DSTest {
 
 	function log(string memory p0, bool p1) internal view {
 		_sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
-	}
-
-    function log(string memory p0, int p1) internal view {
-		_sendLogPayload(abi.encodeWithSignature("log(string,int)", p0, p1));
 	}
 
     function log(string memory p0, string memory p1) internal view {


### PR DESCRIPTION
Added the main `log()` functions directly into `TestUtils`.

Examples of logging in test contracts:
<img width="172" alt="image" src="https://user-images.githubusercontent.com/15525237/215100185-d6671ec8-b21b-4327-b80b-3255ba8c61a3.png">
